### PR TITLE
fix the compile error in reducer

### DIFF
--- a/external/reducer/reducer.hpp
+++ b/external/reducer/reducer.hpp
@@ -18,8 +18,10 @@
 template <class F> class Reducer {
 
 #ifdef __cpp_lib_hardware_interference_size
-  using std::hardware_constructive_interference_size;
-  using std::hardware_destructive_interference_size;
+  static constexpr std::size_t hardware_constructive_interference_size =
+      std::hardware_constructive_interference_size;
+  static constexpr std::size_t hardware_destructive_interference_size =
+      std::hardware_destructive_interference_size;
 #else
   // 64 bytes on x86-64 │ L1_CACHE_BYTES │ L1_CACHE_SHIFT │ __cacheline_aligned
   // │
@@ -61,8 +63,10 @@ public:
 template <class Monoid> class Reducer_with_object {
 
 #ifdef __cpp_lib_hardware_interference_size
-  using std::hardware_constructive_interference_size;
-  using std::hardware_destructive_interference_size;
+  static constexpr std::size_t hardware_constructive_interference_size =
+      std::hardware_constructive_interference_size;
+  static constexpr std::size_t hardware_destructive_interference_size =
+      std::hardware_destructive_interference_size;
 #else
   // 64 bytes on x86-64 │ L1_CACHE_BYTES │ L1_CACHE_SHIFT │ __cacheline_aligned
   // │
@@ -163,8 +167,10 @@ public:
 template <class T> class Reducer_Vector {
 
 #ifdef __cpp_lib_hardware_interference_size
-  using std::hardware_constructive_interference_size;
-  using std::hardware_destructive_interference_size;
+  static constexpr std::size_t hardware_constructive_interference_size =
+      std::hardware_constructive_interference_size;
+  static constexpr std::size_t hardware_destructive_interference_size =
+      std::hardware_destructive_interference_size;
 #else
   // 64 bytes on x86-64 │ L1_CACHE_BYTES │ L1_CACHE_SHIFT │ __cacheline_aligned
   // │


### PR DESCRIPTION
This PR fixed the issue when compiling the BYO using the default command:
```
bazel build benchmarks/run_structures:run_csr
```
with the following error:
```
external/reducer/reducer.hpp:21:14: error: using-declaration for non-member at class scope
   21 |   using std::hardware_constructive_interference_size;
      |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
external/reducer/reducer.hpp:22:14: error: using-declaration for non-member at class scope
   22 |   using std::hardware_destructive_interference_size;
      |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
external/reducer/reducer.hpp:32:13: error: 'hardware_destructive_interference_size' was not declared in this scope; 
did you mean 'std::hardware_destructive_interference_size'?
   32 |     alignas(hardware_destructive_interference_size) F f;
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |             std::hardware_destructive_interference_size

```
compiler: g++ 14.2.1, with pthreds support